### PR TITLE
[lightdm-pantheon-greeter] Refine lightdm-pantheon-greeter-paths.patch

### DIFF
--- a/pantheon/lightdm-pantheon-greeter/PKGBUILD
+++ b/pantheon/lightdm-pantheon-greeter/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=lightdm-pantheon-greeter
 pkgver=2.0.0
-pkgrel=1
+pkgrel=2
 pkgdesc='Pantheon greeter for LightDM'
 arch=('i686' 'x86_64')
 url='https://launchpad.net/pantheon-greeter'
@@ -14,7 +14,7 @@ install='lightdm-pantheon-greeter.install'
 source=("lightdm-pantheon-greeter-${pkgver}.tgz::https://launchpad.net/pantheon-greeter/freya/${pkgver}/+download/pantheon-greeter-${pkgver}.tgz"
         'lightdm-pantheon-greeter-paths.patch')
 sha256sums=('5c81b907f33883e2f40d57d03c3a15e190aae71144143a170dca6cdf87ce6d8f'
-            'c1aaa62b51de44392b2d8581c7596fba5952dfb0f0740d4ed428a3df17672447')
+            '164d93b3dd75a5dfa2ecb4095bbf0f366e778544b4769b4a5c47be1cef952d1b')
 
 prepare() {
   cd pantheon-greeter-${pkgver}

--- a/pantheon/lightdm-pantheon-greeter/lightdm-pantheon-greeter-paths.patch
+++ b/pantheon/lightdm-pantheon-greeter/lightdm-pantheon-greeter-paths.patch
@@ -67,3 +67,15 @@ diff -rupN pantheon-greeter-2.0.0.orig/data/pantheon-greeter.desktop pantheon-gr
 -Type=Application
 -X-Ubuntu-Gettext-Domain=pantheon-greeter
 -Name[en_US]=pantheon-greeter
+diff -rupN pantheon-greeter-2.0.0.orig/src/PantheonGreeter.vala pantheon-greeter-2.0.0/src/PantheonGreeter.vala
+--- pantheon-greeter-2.0.0.orig/src/PantheonGreeter.vala	2015-04-06 23:37:23.000000000 +0200
++++ pantheon-greeter-2.0.0/src/PantheonGreeter.vala	2015-04-20 11:57:44.000000000 +0000
+@@ -81,7 +81,7 @@ public class PantheonGreeter : Gtk.Windo
+ 
+         settings = new KeyFile ();
+         try {
+-            settings.load_from_file (Constants.CONF_DIR+"/pantheon-greeter.conf",
++            settings.load_from_file (Constants.CONF_DIR+"/lightdm-pantheon-greeter.conf",
+                     KeyFileFlags.KEEP_COMMENTS);
+         } catch (Error e) {
+             warning (e.message);


### PR DESCRIPTION
Hello @alucryd ,

Appreciate your great job! `lightdm-pantheon-greeter` try to read `/etc/lightdm/pantheon-greeter.conf` by default, and that file **doesn't exist** because we've patched to rename it to `lightdm-pantheon-greeter.conf`. Then no user config is read by `lightdm-pantheon-greeter`.

This pull request fixes this bug.

Yours sincerely! :bow: 