### PR TITLE
Fix build of lightdm-greeter

### DIFF
--- a/pantheon/lightdm-pantheon-greeter-git/PKGBUILD
+++ b/pantheon/lightdm-pantheon-greeter-git/PKGBUILD
@@ -2,7 +2,7 @@
 # Contributor: sh4nks <sh4nks7@gmail.com
 
 pkgname=lightdm-pantheon-greeter-git
-pkgver=3.3.1.r46.df3d94e
+pkgver=3.3.1.r49.1d9d995
 pkgrel=1
 pkgdesc='Pantheon greeter for LightDM'
 arch=('x86_64')
@@ -27,6 +27,8 @@ pkgver() {
 }
 
 build() {
+  patch -p1 < ../unpatched-gsd.patch  
+
   arch-meson lightdm-pantheon-greeter build
   ninja -C build
 }

--- a/pantheon/lightdm-pantheon-greeter-git/unpatched-gsd.patch
+++ b/pantheon/lightdm-pantheon-greeter-git/unpatched-gsd.patch
@@ -1,0 +1,5 @@
+--- a/lightdm-pantheon-greeter/meson_options.txt
++++ b/lightdm-pantheon-greeter/meson_options.txt
+@@ -1 +1 @@
+-option('ubuntu-patched-gsd', type: 'boolean', value: true) 
++option('ubuntu-patched-gsd', type: 'boolean', value: false) 


### PR DESCRIPTION
Hi, after some searching I figured out why lightdm-pantheon-greeter kept crashing.

This PR adds a patch to disable the `ubuntu-patched-gsd` meson option. I am not familiar with meson at all, so I guess there might be other, cleaner ways to solve this issue.

Also I only fixed the `-git` package because I was not sure how the others work or if there is even an issue with those.